### PR TITLE
Raise more friendly error when credentials are not set

### DIFF
--- a/ubiq_security/decrypt.py
+++ b/ubiq_security/decrypt.py
@@ -62,6 +62,9 @@ class decryption:
             to make the request.
         """
 
+        if not creds.set():
+            raise RuntimeError("credentials not set")
+
         # If the host does not begin with either http or https
         # insert https://
         self._host = creds.host

--- a/ubiq_security/encrypt.py
+++ b/ubiq_security/encrypt.py
@@ -63,6 +63,9 @@ class encryption:
             to make the request.
         """
 
+        if not creds.set():
+            raise RuntimeError("credentials not set")
+
         # If the host does not begin with either http or https
         # insert https://
         self._host = creds.host


### PR DESCRIPTION
When the credentials are not set, an encryption operation will return an error from deep in the API authentication code (as described in issue #1, which does not make obvious what the actual error is. This change modifies the encryption and decryption constructors to check for this occurrence and raise an error:
```
Traceback (most recent call last):
  File "/home/jtyner/Work/Source/test.py", line 8, in <module>
    encrypted_data = ubiq.encrypt(ubiq_creds, "Hi there")
  File "/home/jtyner/Work/Source/ubiq.python/lib/python3.10/site-packages/ubiq_security-1.0.8-py3.10.egg/ubiq_security/encrypt.py", line 224, in encrypt
  File "/home/jtyner/Work/Source/ubiq.python/lib/python3.10/site-packages/ubiq_security-1.0.8-py3.10.egg/ubiq_security/encrypt.py", line 67, in __init__
RuntimeError: credentials not set
```